### PR TITLE
Keep certificates from different hosts in separate lists so as to get…

### DIFF
--- a/src/network/networkaccessmanager.cpp
+++ b/src/network/networkaccessmanager.cpp
@@ -88,6 +88,7 @@
 #include <qsslconfiguration.h>
 #include <qsslerror.h>
 #include <qdatetime.h>
+#include <qstandardpaths.h>
 
 // #define NETWORKACCESSMANAGER_DEBUG
 
@@ -246,8 +247,13 @@ void NetworkAccessManager::sslErrors(QNetworkReply *reply, const QList<QSslError
 #endif
     BrowserMainWindow *mainWindow = BrowserApplication::instance()->mainWindow();
 
+#ifdef _WIN32_WCE
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/knownhosts.ini", QSettings::IniFormat);
+#else
     QSettings settings;
     settings.beginGroup(QLatin1String("knownhosts"));
+#endif
+
     settings.beginGroup(reply->url().host());
 
     QList<QSslCertificate> ca_merge = QSslCertificate::fromData(settings.value(QLatin1String("CaCertificates")).toByteArray());

--- a/src/network/networkaccessmanager.h
+++ b/src/network/networkaccessmanager.h
@@ -102,10 +102,6 @@ private slots:
     void privacyChanged(bool isPrivate);
 
 private:
-#ifndef QT_NO_OPENSSL
-    static QString certToFormattedString(QSslCertificate cert);
-#endif
-
     QByteArray m_acceptLanguage;
     QHash<QString, SchemeAccessHandler*> m_schemeHandlers;
 


### PR DESCRIPTION
… less easily fooled by stolen certificates / Combine the two involved message boxes in one which, upon click on Show Details, expands to show full certificate details including the thumbprint, and offers a checkbox to control whether the certificate will be imported to the trust list (which might actually be better described by the term exception list, but I'm undecided on that).

The proposed change is meant to improve both usability and security of certificate error handling, esp in scenarios where self-signed certificates are predominant.